### PR TITLE
Change vimeo90k_septuplet script

### DIFF
--- a/dataset/vimeo90k_septuplet.py
+++ b/dataset/vimeo90k_septuplet.py
@@ -20,14 +20,15 @@ class VimeoSepTuplet(Dataset):
         self.training = is_training
         self.inputs = input_frames
 
-        train_fn = os.path.join(self.data_root, 'sep_trainlist.txt')
         test_fn = os.path.join(self.data_root, 'sep_testlist.txt')
-        with open(train_fn, 'r') as f:
-            self.trainlist = f.read().splitlines()
         with open(test_fn, 'r') as f:
             self.testlist = f.read().splitlines()
 
         if self.training:
+            train_fn = os.path.join(self.data_root, 'sep_trainlist.txt')
+            with open(train_fn, 'r') as f:
+                self.trainlist = f.read().splitlines()
+
             self.transforms = transforms.Compose([
                 transforms.RandomCrop(256),
                 transforms.RandomHorizontalFlip(0.5),


### PR DESCRIPTION
Hey @tarun005, 
Amazing work. Really enjoyed the approach for multi frame interpolation. This PR makes some changes in the `vimeo90k_septuplet.py` which prevents it from reading in the training dataset while testing. In this way, one does not has to download the entire 80gig(training + testing) dataset just for testing. I tried it just with the `vimeo septuplet` testing dataset and could reproduce similar results as given in the paper.